### PR TITLE
Initiating Parallel Tempering for MCMC

### DIFF
--- a/MCMC-flow/init.py
+++ b/MCMC-flow/init.py
@@ -20,34 +20,31 @@ def get_parameters():
     parameters = OrderedDict()
 
     # system parameters
-    # Put your density state points here:
     parameters["n_density"] = [0.5]
     parameters["n_particles"] = [100]
     parameters["r"] = [0.5]
     parameters["r_cut"] = [2.5]
     parameters["energy_func"] = ["lj"]
-    parameters["hard_sphere"] = [False]
+    parameters["hard_sphere"] = [True]
 
     # LJ energy parameters
     parameters["epsilon"] = [1.0]
-    parameters["sigma"] = [1.0]
+    parameters["sigma"] = [0.5]
     parameters["n"] = [12]
     parameters["m"] = [6]
-    parameters["e_factor"] = [[0.01, 0.1, 0.5, 1.0]]
 
     # logging parameters
     parameters["energy_write_freq"] = [1000]
     parameters["trajectory_write_freq"] = [10000]
 
     # run parameters
-    parameters["n_steps"] = [[2e7, 2e7]]
-    # Put your temperatures here, remember each one is a list of 2 temperatures
-    # First, the mixing temperature, which we'll keep at 10 for all jobs
-    # Second, the state point temperature
-    parameters["kT"] = [
-        [10, 1.5]
-    ]
-    parameters["max_trans"] = [[0.5, 0.5]]
+    parameters["mixing_steps"] = [2000]
+    parameters["mixing_kT"] = [10]
+    parameters["mixing_max_trans"] = [0.5]
+
+    parameters["n_steps"] = [[2000]]
+    parameters["kT"] = [[1.5]]
+    parameters["max_trans"] = [[0.5]]
     parameters["seed"] = [20]
 
     return list(parameters.keys()), list(product(*parameters.values()))
@@ -57,43 +54,34 @@ custom_job_doc = {}  # add keys and values for each job document created
 
 
 def main():
-    project = signac.init_project("MC-den-temp-sweep")  # Set the signac project name
+    project = signac.init_project("MCMC-project")  # Set the signac project name
     param_names, param_combinations = get_parameters()
     # Create jobs
     for params in param_combinations:
         parent_statepoint = dict(zip(param_names, params))
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
+        parent_job.doc.setdefault("job_type", "sim")
+        parent_job.doc.setdefault("swap", False)
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("current_run", 0)
+        parent_job.doc.setdefault("mixed", False)
         parent_job.doc.setdefault("timestep", [])
         parent_job.doc.setdefault("accepted_moves", [])
         parent_job.doc.setdefault("rejected_moves", [])
         parent_job.doc.setdefault("acceptance_ratio", [])
         parent_job.doc.setdefault("tps", [])
         parent_job.doc.setdefault("energy", [])
-        # each pair of (`n_steps`, `kT`) defines a phase of simulation run. The `phase_{i}` key in job doc determines
-        # whether that phase is already done or not. False means phase is not done.
-        n_steps_size = len(parent_statepoint['n_steps'])
-        kT_size = len(parent_statepoint['kT'])
-        max_trans_size = len(parent_statepoint['max_trans'])
-        if n_steps_size == kT_size == max_trans_size:
-            for i in range(1, n_steps_size + 1):
-                parent_job.doc.setdefault("phase_{}".format(i), False)
-        else:
-            raise ValueError(
-                "These lists must have the same length: `n_steps`, `kT` and `max_trans` for each job! \n "
-                "`n_step` size: {}, `kT` size: {}, `max_trans` size: {}".format(n_steps_size, kT_size, max_trans_size))
     if custom_job_doc:
         for key in custom_job_doc:
             parent_job.doc.setdefault(key, custom_job_doc[key])
 
     project.write_statepoints()
 
-
-def init_project():
+def init_jobs():
     logging.basicConfig(level=logging.INFO)
     main()
 
 
 if __name__ == "__main__":
-    init_project()
+    init_jobs()

--- a/MCMC-flow/init.py
+++ b/MCMC-flow/init.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Initialize the project's data space.
+Iterates over all defined state points and initializes
+the associated job workspace directories.
+The result of running this file is the creation of a signac workspace:
+    - signac.rc file containing the project name
+    - signac_statepoints.json summary for the entire workspace
+    - workspace/ directory that contains a sub-directory of every individual statepoint
+    - signac_statepoints.json within each individual statepoint sub-directory.
+"""
+
+import logging
+from collections import OrderedDict
+from itertools import product
+
+import signac
+
+
+def get_parameters():
+    parameters = OrderedDict()
+
+    # system parameters
+    # Put your density state points here:
+    parameters["n_density"] = [0.5]
+    parameters["n_particles"] = [100]
+    parameters["r"] = [0.5]
+    parameters["r_cut"] = [2.5]
+    parameters["energy_func"] = ["lj"]
+    parameters["hard_sphere"] = [False]
+
+    # LJ energy parameters
+    parameters["epsilon"] = [1.0]
+    parameters["sigma"] = [1.0]
+    parameters["n"] = [12]
+    parameters["m"] = [6]
+    parameters["e_factor"] = [[0.01, 0.1, 0.5, 1.0]]
+
+    # logging parameters
+    parameters["energy_write_freq"] = [1000]
+    parameters["trajectory_write_freq"] = [10000]
+
+    # run parameters
+    parameters["n_steps"] = [[2e7, 2e7]]
+    # Put your temperatures here, remember each one is a list of 2 temperatures
+    # First, the mixing temperature, which we'll keep at 10 for all jobs
+    # Second, the state point temperature
+    parameters["kT"] = [
+            [10, 1.5]
+    ]
+    parameters["max_trans"] = [[0.5, 0.5]]
+    parameters["seed"] = [20]
+
+
+    return list(parameters.keys()), list(product(*parameters.values()))
+
+
+custom_job_doc = {}  # add keys and values for each job document created
+
+
+def main():
+    project = signac.init_project("MC-den-temp-sweep")  # Set the signac project name
+    param_names, param_combinations = get_parameters()
+    # Create jobs
+    for params in param_combinations:
+        parent_statepoint = dict(zip(param_names, params))
+        parent_job = project.open_job(parent_statepoint)
+        parent_job.init()
+        parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("timestep", [])
+        parent_job.doc.setdefault("accepted_moves", [])
+        parent_job.doc.setdefault("rejected_moves", [])
+        parent_job.doc.setdefault("acceptance_ratio", [])
+        parent_job.doc.setdefault("tps", [])
+        parent_job.doc.setdefault("energy", [])
+        # each pair of (`n_steps`, `kT`) defines a phase of simulation run. The `phase_{i}` key in job doc determines
+        # whether that phase is already done or not. False means phase is not done.
+        n_steps_size = len(parent_statepoint['n_steps'])
+        kT_size = len(parent_statepoint['kT'])
+        max_trans_size = len(parent_statepoint['max_trans'])
+        if n_steps_size == kT_size == max_trans_size:
+            for i in range(1, n_steps_size + 1):
+                parent_job.doc.setdefault("phase_{}".format(i), False)
+        else:
+            raise ValueError(
+                "These lists must have the same length: `n_steps`, `kT` and `max_trans` for each job! \n "
+                "`n_step` size: {}, `kT` size: {}, `max_trans` size: {}".format(n_steps_size, kT_size, max_trans_size))
+    if custom_job_doc:
+        for key in custom_job_doc:
+            parent_job.doc.setdefault(key, custom_job_doc[key])
+
+    project.write_statepoints()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/MCMC-flow/init.py
+++ b/MCMC-flow/init.py
@@ -45,11 +45,10 @@ def get_parameters():
     # First, the mixing temperature, which we'll keep at 10 for all jobs
     # Second, the state point temperature
     parameters["kT"] = [
-            [10, 1.5]
+        [10, 1.5]
     ]
     parameters["max_trans"] = [[0.5, 0.5]]
     parameters["seed"] = [20]
-
 
     return list(parameters.keys()), list(product(*parameters.values()))
 
@@ -91,6 +90,10 @@ def main():
     project.write_statepoints()
 
 
-if __name__ == "__main__":
+def init_project():
     logging.basicConfig(level=logging.INFO)
     main()
+
+
+if __name__ == "__main__":
+    init_project()

--- a/MCMC-flow/init.py
+++ b/MCMC-flow/init.py
@@ -32,6 +32,7 @@ def get_parameters():
     parameters["sigma"] = [0.5]
     parameters["n"] = [12]
     parameters["m"] = [6]
+    parameters["e_factor"] = [0.1, 0.2, 0.5, 1.]
 
     # logging parameters
     parameters["energy_write_freq"] = [1000]

--- a/MCMC-flow/init.py
+++ b/MCMC-flow/init.py
@@ -21,7 +21,7 @@ def get_parameters():
 
     # system parameters
     parameters["n_density"] = [0.5]
-    parameters["n_particles"] = [100]
+    parameters["n_particles"] = [10]
     parameters["r"] = [0.5]
     parameters["r_cut"] = [2.5]
     parameters["energy_func"] = ["lj"]
@@ -35,15 +35,15 @@ def get_parameters():
     parameters["e_factor"] = [0.1, 0.2, 0.5, 1.]
 
     # logging parameters
-    parameters["energy_write_freq"] = [1000]
-    parameters["trajectory_write_freq"] = [10000]
+    parameters["energy_write_freq"] = [10]
+    parameters["trajectory_write_freq"] = [10]
 
     # run parameters
-    parameters["mixing_steps"] = [2000]
+    parameters["mixing_steps"] = [200]
     parameters["mixing_kT"] = [10]
     parameters["mixing_max_trans"] = [0.5]
 
-    parameters["n_steps"] = [[2000]]
+    parameters["n_steps"] = [[200]]
     parameters["kT"] = [[1.5]]
     parameters["max_trans"] = [[0.5]]
     parameters["seed"] = [20]
@@ -54,8 +54,8 @@ def get_parameters():
 custom_job_doc = {}  # add keys and values for each job document created
 
 
-def main():
-    project = signac.init_project("MCMC-project")  # Set the signac project name
+def main(root):
+    project = signac.init_project("MCMC-project", root=root)  # Set the signac project name
     param_names, param_combinations = get_parameters()
     # Create jobs
     for params in param_combinations:
@@ -79,9 +79,9 @@ def main():
 
     project.write_statepoints()
 
-def init_jobs():
+def init_jobs(root='../'):
     logging.basicConfig(level=logging.INFO)
-    main()
+    main(root)
 
 
 if __name__ == "__main__":

--- a/MCMC-flow/project.py
+++ b/MCMC-flow/project.py
@@ -3,8 +3,8 @@ Execute this script directly from the command line, to view your project's
 status, execute operations and submit them to a cluster. See also:
     $ python src/project.py --help
 """
-import sys
 import os
+import sys
 
 # getting the name of the directory
 # where the this file is present.
@@ -81,9 +81,11 @@ def sampled(job):
 def initialized(job):
     return job.isfile("trajectory.gsd")
 
+
 @MyProject.label
 def is_sim(job):
     return job.doc["job_type"] == "sim"
+
 
 @directives(executable="python -u")
 @MyProject.operation
@@ -104,7 +106,8 @@ def sample(job):
         sim = Simulation(n_particles=job.sp.n_particles, n_density=job.sp.n_density, r=job.sp.r, r_cut=job.sp.r_cut,
                          energy_write_freq=job.sp.energy_write_freq, trajectory_write_freq=job.sp.trajectory_write_freq,
                          energy_func=ENERGY_FUNCS[job.sp.energy_func], hard_sphere=job.sp.hard_sphere, restart=restart,
-                         sigma=job.sp.sigma, epsilon=job.sp.epsilon, n=job.sp.n, m=job.sp.m, seed=job.sp.seed)
+                         sigma=job.sp.sigma, epsilon=job.sp.epsilon, n=job.sp.n, m=job.sp.m, e_factor=job.sp.e_factor,
+                         seed=job.sp.seed)
         job.doc["L"] = sim.L
 
         print("----------------------")

--- a/MCMC-flow/project.py
+++ b/MCMC-flow/project.py
@@ -1,0 +1,137 @@
+"""Define the project's workflow logic and operation functions.
+Execute this script directly from the command line, to view your project's
+status, execute operations and submit them to a cluster. See also:
+    $ python src/project.py --help
+"""
+import sys
+import os
+
+# getting the name of the directory
+# where the this file is present.
+current = os.path.dirname(os.path.realpath(__file__))
+
+# Getting the parent directory name
+# where the current directory is present.
+parent = os.path.dirname(current)
+
+# adding the parent directory to
+# the sys.path.
+sys.path.append(parent)
+
+from flow import FlowProject, directives
+from flow.environment import DefaultSlurmEnvironment
+from simulation import Simulation
+from utils import inverse_distance_attractive, inverse_distance_repulsive, lj_energy
+
+ENERGY_FUNCS = {"lj": lj_energy,
+                "i_dist_att": inverse_distance_attractive,
+                "i_dist_rep": inverse_distance_repulsive}
+
+
+class MyProject(FlowProject):
+    pass
+
+
+class Borah(DefaultSlurmEnvironment):
+    hostname_pattern = "borah"
+    template = "borah.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="short",
+            help="Specify the partition to submit to."
+        )
+
+
+class R2(DefaultSlurmEnvironment):
+    hostname_pattern = "r2"
+    template = "r2.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="shortq",
+            help="Specify the partition to submit to."
+        )
+
+
+class Fry(DefaultSlurmEnvironment):
+    hostname_pattern = "fry"
+    template = "fry.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="batch",
+            help="Specify the partition to submit to."
+        )
+
+
+# Definition of project-related labels (classification)
+@MyProject.label
+def sampled(job):
+    return job.doc.get("done")
+
+
+@MyProject.label
+def initialized(job):
+    return job.isfile("trajectory.gsd")
+
+
+@directives(executable="python -u")
+@MyProject.operation
+@MyProject.post(sampled)
+def sample(job):
+    with job:
+        print("-----------------------")
+        print("JOB ID NUMBER:")
+        print(job.id)
+        print("-----------------------")
+        print("----------------------")
+        print("Creating the system...")
+        print("----------------------")
+
+        # Setting up the system
+        restart = job.isfile("system.txt")
+        sim = Simulation(n_particles=job.sp.n_particles, n_density=job.sp.n_density, r=job.sp.r, r_cut=job.sp.r_cut,
+                         energy_write_freq=job.sp.energy_write_freq, trajectory_write_freq=job.sp.trajectory_write_freq,
+                         energy_func=ENERGY_FUNCS[job.sp.energy_func], hard_sphere=job.sp.hard_sphere, restart=restart,
+                         sigma=job.sp.sigma, epsilon=job.sp.epsilon, n=job.sp.n, m=job.sp.m, e_factor=job.sp.e_factor,
+                         seed=job.sp.seed)
+        job.doc["L"] = sim.L
+
+        print("----------------------")
+        print("System generated...")
+        print("----------------------")
+        print("----------------------")
+        print("Starting simulation...")
+        print("----------------------")
+        # Running the simulation
+        for i, (n_steps, kT, max_trans) in enumerate(zip(job.sp.n_steps, job.sp.kT, job.sp.max_trans)):
+            current_run = i+1
+            if not job.doc["phase_{}".format(current_run)]:
+                sim.run(n_steps=n_steps, kT=kT, max_trans=max_trans)
+                sim.save_trajectory(fname="trajectory_{}.gsd".format(i))
+                sim.save_system()
+                job.doc["timestep"].append(sim.timestep)
+                job.doc["accepted_moves"].append(sim.accepted_moves)
+                job.doc["rejected_moves"].append(sim.rejected_moves)
+                job.doc["acceptance_ratio"].append(sim.acceptance_ratio)
+                job.doc["tps"].append(sim.tps)
+                job.doc["energy"].append(sim.energy)
+                job.doc["phase_{}".format(current_run)] = True
+                sim.reset_system()
+
+        if sum(job.doc["timestep"]) == sum(job.sp.n_steps):
+            job.doc["done"] = True
+        print("-----------------------------")
+        print("Simulation finished completed")
+        print("-----------------------------")
+
+
+if __name__ == "__main__":
+    MyProject().main()

--- a/MCMC-flow/project.py
+++ b/MCMC-flow/project.py
@@ -81,10 +81,14 @@ def sampled(job):
 def initialized(job):
     return job.isfile("trajectory.gsd")
 
+@MyProject.label
+def is_sim(job):
+    return job.doc["job_type"] == "sim"
 
 @directives(executable="python -u")
 @MyProject.operation
 @MyProject.post(sampled)
+@MyProject.pre(is_sim)
 def sample(job):
     with job:
         print("-----------------------")
@@ -96,38 +100,55 @@ def sample(job):
         print("----------------------")
 
         # Setting up the system
-        restart = job.isfile("system.txt")
+        restart = job.isfile("restart.gsd")
         sim = Simulation(n_particles=job.sp.n_particles, n_density=job.sp.n_density, r=job.sp.r, r_cut=job.sp.r_cut,
                          energy_write_freq=job.sp.energy_write_freq, trajectory_write_freq=job.sp.trajectory_write_freq,
                          energy_func=ENERGY_FUNCS[job.sp.energy_func], hard_sphere=job.sp.hard_sphere, restart=restart,
-                         sigma=job.sp.sigma, epsilon=job.sp.epsilon, n=job.sp.n, m=job.sp.m, e_factor=job.sp.e_factor,
-                         seed=job.sp.seed)
+                         sigma=job.sp.sigma, epsilon=job.sp.epsilon, n=job.sp.n, m=job.sp.m, seed=job.sp.seed)
         job.doc["L"] = sim.L
 
         print("----------------------")
         print("System generated...")
         print("----------------------")
+        # running mixing step if not done before
+        if not job.doc["mixed"]:
+            print("----------------------")
+            print("Starting mixing simulation...")
+            print("----------------------")
+            sim.run(n_steps=job.sp.mixing_steps, kT=job.sp.mixing_kT, max_trans=job.sp.mixing_max_trans)
+            sim.save_trajectory(fname="trajectory_mixing.gsd")
+            job.doc["timestep"].append(sim.timestep)
+            job.doc["accepted_moves"].append(sim.accepted_moves)
+            job.doc["rejected_moves"].append(sim.rejected_moves)
+            job.doc["acceptance_ratio"].append(sim.acceptance_ratio)
+            job.doc["tps"].append(sim.tps)
+            job.doc["energy"].append(sim.energy)
+            job.doc["mixed"] = True
+            sim.reset_system()
+
         print("----------------------")
         print("Starting simulation...")
         print("----------------------")
         # Running the simulation
-        for i, (n_steps, kT, max_trans) in enumerate(zip(job.sp.n_steps, job.sp.kT, job.sp.max_trans)):
-            current_run = i+1
-            if not job.doc["phase_{}".format(current_run)]:
-                sim.run(n_steps=n_steps, kT=kT, max_trans=max_trans)
-                sim.save_trajectory(fname="trajectory_{}.gsd".format(i))
-                sim.save_system()
-                job.doc["timestep"].append(sim.timestep)
-                job.doc["accepted_moves"].append(sim.accepted_moves)
-                job.doc["rejected_moves"].append(sim.rejected_moves)
-                job.doc["acceptance_ratio"].append(sim.acceptance_ratio)
-                job.doc["tps"].append(sim.tps)
-                job.doc["energy"].append(sim.energy)
-                job.doc["phase_{}".format(current_run)] = True
-                sim.reset_system()
+        for (n_steps, kT, max_trans) in zip(job.sp.n_steps, job.sp.kT, job.sp.max_trans):
+            sim.run(n_steps=n_steps, kT=kT, max_trans=max_trans)
+            if job.doc["swap"]:
+                sim.save_trajectory(fname="trajectory_{}_swap.gsd".format(job.doc["current_run"]))
+            else:
+                sim.save_trajectory(fname="trajectory_{}.gsd".format(job.doc["current_run"]))
+            sim.save_snapshot('restart.gsd')
+            job.doc["timestep"].append(sim.timestep)
+            job.doc["accepted_moves"].append(sim.accepted_moves)
+            job.doc["rejected_moves"].append(sim.rejected_moves)
+            job.doc["acceptance_ratio"].append(sim.acceptance_ratio)
+            job.doc["tps"].append(sim.tps)
+            job.doc["energy"].append(sim.energy)
+            job.doc["phase_{}".format(job.doc["current_run"])] = True
+            sim.reset_system()
+            job.doc["current_run"] += 1
 
-        if sum(job.doc["timestep"]) == sum(job.sp.n_steps):
-            job.doc["done"] = True
+        # TODO: Find a way to check the timestep based on all the run attempts from PT.
+        job.doc["done"] = True
         print("-----------------------------")
         print("Simulation finished completed")
         print("-----------------------------")

--- a/PT-flow/init.py
+++ b/PT-flow/init.py
@@ -21,9 +21,11 @@ def get_parameters():
 
     # system parameters
     # Put your density state points here:
-    parameters["mode"] = ["MC"]
+    parameters["mode"] = ["MCMC-flow"]
     parameters["workspace"] = ["../MCMC-flow/"]
     parameters["n_attempts"] = [10]
+    parameters["PT_n_steps"] = [[1e6]]
+    parameters["PT_kT"] = [[1.5]]
     parameters["seed"] = [20]
 
     return list(parameters.keys()), list(product(*parameters.values()))

--- a/PT-flow/init.py
+++ b/PT-flow/init.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Initialize the project's data space.
+Iterates over all defined state points and initializes
+the associated job workspace directories.
+The result of running this file is the creation of a signac workspace:
+    - signac.rc file containing the project name
+    - signac_statepoints.json summary for the entire workspace
+    - workspace/ directory that contains a sub-directory of every individual statepoint
+    - signac_statepoints.json within each individual statepoint sub-directory.
+"""
+
+import logging
+from collections import OrderedDict
+from itertools import product
+
+import signac
+
+
+def get_parameters():
+    parameters = OrderedDict()
+
+    # system parameters
+    # Put your density state points here:
+    parameters["mode"] = ["MC"]
+    parameters["workspace"] = ["../MCMC-flow/"]
+    parameters["n_attempts"] = [10]
+    parameters["seed"] = [20]
+
+    return list(parameters.keys()), list(product(*parameters.values()))
+
+
+def main():
+    project = signac.init_project("parallel-tempering")  # Set the signac project name
+    param_names, param_combinations = get_parameters()
+    # Create jobs
+    for params in param_combinations:
+        parent_statepoint = dict(zip(param_names, params))
+        parent_job = project.open_job(parent_statepoint)
+        parent_job.init()
+        parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("current_attempt", 0)
+        parent_job.doc.setdefault("swap_history", [])
+        parent_job.doc.setdefault("accepted_attempts", [])
+
+    project.write_statepoints()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/PT-flow/init_PT.py
+++ b/PT-flow/init_PT.py
@@ -30,9 +30,9 @@ def get_parameters():
     # initial wait time (in seconds) before checking the status of jobs
     parameters["init_wait"] = [3600]
     # additional wait time (in seconds) after the first wait time is over and jobs are still not done
-    parameters["additional_wait"] = [600]
+    parameters["extra_wait"] = [600]
     # maximum wait time (in seconds)
-    parameters["max_wait"] = [10800]
+    parameters["max_tries"] = [5]
 
     return list(parameters.keys()), list(product(*parameters.values()))
 

--- a/PT-flow/init_PT.py
+++ b/PT-flow/init_PT.py
@@ -19,14 +19,20 @@ import signac
 def get_parameters():
     parameters = OrderedDict()
 
-    # system parameters
-    # Put your density state points here:
+    # simulation mode: MCMC-flow or polymer-flow
     parameters["mode"] = ["MCMC-flow"]
-    parameters["workspace"] = ["../MCMC-flow/"]
-    parameters["n_attempts"] = [10]
+    # number of run steps between swaps
     parameters["PT_n_steps"] = [[1e6]]
-    parameters["PT_kT"] = [[1.5]]
     parameters["seed"] = [20]
+
+    # total number of swaps
+    parameters["n_attempts"] = [10]
+    # initial wait time (in seconds) before checking the status of jobs
+    parameters["init_wait"] = [3600]
+    # additional wait time (in seconds) after the first wait time is over and jobs are still not done
+    parameters["additional_wait"] = [600]
+    # maximum wait time (in seconds)
+    parameters["max_wait"] = [10800]
 
     return list(parameters.keys()), list(product(*parameters.values()))
 
@@ -40,6 +46,7 @@ def main():
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("job_type", "PT")
         parent_job.doc.setdefault("current_attempt", 0)
         parent_job.doc.setdefault("swap_history", [])
         parent_job.doc.setdefault("accepted_attempts", [])

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -93,7 +93,7 @@ def sample(job):
         print("-----------------------")
         # import files from signac flow
         sys.path.append("../{}/".format(job.sp.mode))
-        from init import init_project
+        from init import init_jobs
         from project import MyProject
 
         # Before first swap attempt, first we need to initiate signac project and submit jobs.
@@ -106,7 +106,8 @@ def sample(job):
             print("----------------------")
 
             try:
-                init_project()
+                init_jobs()
+                logger.info("Successfully initiated {} project...".format(job.sp.mode))
                 print("----------------------")
                 print("Successfully initiated {} project...".format(job.sp.mode))
                 print("----------------------")
@@ -123,8 +124,6 @@ def sample(job):
             except Exception as error:
                 logger.error(f"Error at line: {error.args[0]}")
                 raise RuntimeError("project submission failed")
-            #TODO: If we can find a way to check the status of submitted jobs frequently here
-            # (maybe using a while loop), then we can move on to the next step easily.
 
         else:
             # find signac project

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -232,23 +232,17 @@ def sample(job):
 
                 snapshot_i = gsd.hoomd.open(job_i.fn("restart.gsd"))[0]
                 positions_i = copy.deepcopy(snapshot_i.particles.position)
-                print("i: ", positions_i)
+
                 snapshot_j = gsd.hoomd.open(job_j.fn("restart.gsd"))[0]
-                positions_j = copy.deepcopy(snapshot_i.particles.position)
-                print("j: ", positions_j)
+                positions_j = copy.deepcopy(snapshot_j.particles.position)
+
                 # swap positions and save snapshot
                 with gsd.hoomd.open(job_i.fn("restart.gsd"), "wb") as traj:
                     snapshot_i.particles.position = positions_j
                     traj.append(snapshot_i)
-                snapshot_i = gsd.hoomd.open(job_i.fn("restart.gsd"))[0]
-                print('swap i: ', snapshot_i.particles.position)
-                print('done snap i')
                 with gsd.hoomd.open(job_j.fn("restart.gsd"), "wb") as traj:
                     snapshot_j.particles.position = positions_i
                     traj.append(snapshot_j)
-                snapshot_j = gsd.hoomd.open(job_j.fn("restart.gsd"))[0]
-                print('swap j: ', snapshot_j.particles.position)
-                print('done snap j')
 
                 # submit simulations
                 submit_sims(MyProject())

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -212,10 +212,13 @@ def sample(job):
                 print("----------------------")
                 project = signac.get_project()
                 sim_jobs = list(project.find_jobs({"doc.job_type": "sim"}).groupby("e_factor"))
+                print(sim_jobs)
                 # find a random job and a neighbor to swap their configurations
                 i = random.randint(1, len(sim_jobs) - 1)
+                print(i)
                 # find the neighbor with lower e_factor (equivalent to higher T)
                 j = i - 1
+                print(j)
                 e_factor_i = sim_jobs[i][0]
                 job_i = list(sim_jobs[i][1])[0]
 

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -62,7 +62,7 @@ class R2(DefaultSlurmEnvironment):
 
 class Fry(DefaultSlurmEnvironment):
     hostname_pattern = "fry"
-    template = "../templates/fry.sh"
+    template = "fry.sh"
 
     @classmethod
     def add_args(cls, parser):
@@ -147,9 +147,9 @@ def submit_sims(job, project):
     try:
         project.submit()
         print("----------------------")
-        print("Successfully submitted {} project...".format(job.sp.mode))
+        print("Successfully submitted {} project...".format(job.sp))
         print("----------------------")
-        logger.info("Successfully submitted {} project...".format(job.sp.mode))
+        logger.info("Successfully submitted {} project...".format(job.sp))
     except Exception as error:
         logger.error(f"Error at line: {error.args[0]}")
         raise RuntimeError("project submission failed")
@@ -165,7 +165,9 @@ def sample(job):
         print(job.id)
         print("-----------------------")
         # import files from signac flow
-        sys.path.append("../{}/".format(job.sp.mode))
+        project = signac.get_project()
+        path = os.path.join(project.root_directory(), "../{}/".format(job.sp.mode))
+        sys.path.append(path)
         from init import init_jobs
         from project import MyProject
 
@@ -209,7 +211,7 @@ def sample(job):
                 print("Initiating a swap...")
                 print("----------------------")
                 project = signac.get_project()
-                sim_jobs = project.find_jobs({"doc.job_type": "sim"}).groupby("e_factor")
+                sim_jobs = list(project.find_jobs({"doc.job_type": "sim"}).groupby("e_factor"))
                 # find a random job and a neighbor to swap their configurations
                 i = random.randint(1, len(sim_jobs) - 1)
                 # find the neighbor with lower e_factor (equivalent to higher T)

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -5,6 +5,7 @@ status, execute operations and submit them to a cluster. See also:
 """
 import os
 import sys
+import time
 
 # getting the name of the directory
 # where the this file is present.
@@ -28,7 +29,8 @@ import logging
 
 logger = logging.getLogger()
 
-class MyProject(FlowProject):
+
+class PT_Project(FlowProject):
     pass
 
 
@@ -72,27 +74,90 @@ class Fry(DefaultSlurmEnvironment):
 
 
 # Definition of project-related labels (classification)
-@MyProject.label
+@PT_Project.label
 def finished(job):
     return job.doc.get("done")
 
 
-@MyProject.label
+@PT_Project.label
 def initialized(job):
     return job.doc.get("current_attempt") > 0
 
 
-def sims_done():
+def wait(init_wait, extra_wait, max_tries):
+    """
+    Waits for a certain amount of time for the simulations to finish.
+    :param init_wait: Initial wait time before first status check.
+    :param extra_wait: Wait time between status checks.
+    :param max_tries: Maximum number of status checks.
+    :return:
+    """
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            retries = 0
+            start_init = time.time()
+            print('initial sleep.....')
+            time.sleep(init_wait)
+            print('init wait time: ', time.time() - start_init)
+            while retries < max_tries:
+                print('try: ', retries)
+                value = function(*args, **kwargs)
+                if value:
+                    return value
+                else:
+                    start_add = time.time()
+                    print('additional sleep.....')
+                    time.sleep(extra_wait)
+                    print('additional wait: ', time.time() - start_add)
+                    retries += 1
+            return False
+
+        return wrapper
+
+    return decorator
+
+
+def get_sim_jobs():
     project = signac.get_project()
     jobs_list = project.find_jobs({'doc.job_type': "sim"})
-    return all([job.doc["done"] for job in jobs_list])
+    return jobs_list
 
 
+def check_status(init_wait, extra_wait, max_tries):
+    @wait(init_wait, extra_wait, max_tries)
+    def _check_status():
+        return all([job.doc["done"] for job in get_sim_jobs()])
+
+    return _check_status()
+
+
+def update_swap_info(swap):
+    swap["done"] = True
+    project = signac.get_project()
+    job_i = project.open_job(id=swap["job_i"])
+    job_j = project.open_job(id=swap["job_j"])
+    # job i and j from previous swap no longer need the swap flag to be True.
+    job_i.doc["swap"] = False
+    job_j.doc["swap"] = False
+
+
+def submit_sims(job, project):
+    for job in get_sim_jobs():
+        job.doc["done"] = False
+    try:
+        project.submit()
+        print("----------------------")
+        print("Successfully submitted {} project...".format(job.sp.mode))
+        print("----------------------")
+        logger.info("Successfully submitted {} project...".format(job.sp.mode))
+    except Exception as error:
+        logger.error(f"Error at line: {error.args[0]}")
+        raise RuntimeError("project submission failed")
 
 
 @directives(executable="python -u")
-@MyProject.operation
-@MyProject.post(finished)
+@PT_Project.operation
+@PT_Project.post(finished)
 def sample(job):
     with job:
         print("-----------------------")
@@ -104,6 +169,9 @@ def sample(job):
         from init import init_jobs
         from project import MyProject
 
+        init_wait = job.sp.init_wait
+        extra_wait = job.sp.extra_wait
+        max_tries = job.sp.max_tries
         # Before first swap attempt, first we need to initiate signac project and submit jobs.
         if job.doc["current_attempt"] == 0:
             print("----------------------")
@@ -123,94 +191,61 @@ def sample(job):
                 logger.error(f"Error at line: {error.args[0]}")
                 raise RuntimeError("project init failed")
 
-            try:
-                MyProject().submit()
-                print("----------------------")
-                print("Successfully submitted {} project...".format(job.sp.mode))
-                print("----------------------")
-                logger.info("Successfully submitted {} project...".format(job.sp.mode))
-            except Exception as error:
-                logger.error(f"Error at line: {error.args[0]}")
-                raise RuntimeError("project submission failed")
+            submit_sims(job, MyProject())
 
         while job.doc["current_attempt"] <= job.sp.n_attempts:
-            # find signac project
+            # First, making sure the simulations are finished
+            if check_status(init_wait, extra_wait, max_tries):
+                if job.doc["current_attempt"] > 0:
+                    # find the last swap
+                    last_swap = job.doc["swap_history"][-1]
+                    # update last swap information
+                    update_swap_info(last_swap)
 
-
-            # First, making sure the previous swap (if exists) was finished successfully
-            if is_finished(jobs_list)
-        if job.doc["current_attempt"] > 0:
-            # find the last swap
-            last_swap = job.doc["swap_history"][-1]
-
-            job_i = project.open_job(id=last_swap["job_i"])
-            job_j = project.open_job(id=last_swap["job_j"])
-
-            # TODO: probably need to check all the jobs, but for now we only check i & j status
-            try:
-                assert job_i.doc["done"] and job_j.doc["done"]
-                job.doc["swap_history"][-1]["done"] = True
-            except AssertionError:
-                # previous swap was unsuccessful, need to repeat.
-                job.doc["current_attempt"] -= 1
-
-        if job.doc["current_attempt"] <= job.sp.n_attempts:
-            print("----------------------")
-            print("Initiating a swap...")
-            print("----------------------")
-            # find a random job and a neighbor to swap their configurations
-            i = random.randint(1, len(jobs_list) - 1)
-            # find the neighbor with lower e_factor (equivalent to higher T)
-            j = i - 1
-            e_factor_i = jobs_list[i][0]
-            job_i = list(jobs_list[i][1])[0]
-
-            e_factor_j = jobs_list[j][0]
-            job_j = list(jobs_list[j][1])[0]
-            # TODO: get potential energy for both and calculate acceptance criteria.
-
-            print("----------------------")
-            print("Swapping e_factor {} with {}...".format(e_factor_i, e_factor_j))
-            print("----------------------")
-            # Accepting the swap
-            job.doc["swap_history"].append({"i": i, "j": j, "e_factor_i": e_factor_i, "e_factor_j": e_factor_j,
-                                            "job_i": job_i, "job_j": job_j, "done": False})
-            job.doc["current_attempt"] += 1
-
-            snapshot_i = gsd.hoomd.open(job_i.fn("snapshot.gsd"))[0]
-            positions_i = copy.deepcopy(snapshot_i.particles.position)
-
-            snapshot_j = job_j.fn("snapshot.gsd")[0]
-            positions_j = copy.deepcopy(snapshot_i.particles.position)
-
-            # swap positions and save snapshot
-            with gsd.hoomd.open(job_i.fn("snapshot.gsd"), "w") as traj:
-                snapshot_i.particle.position = positions_j
-                traj.append(snapshot_i)
-
-            with gsd.hoomd.open(job_j.fn("snapshot.gsd"), "w") as traj:
-                snapshot_j.particle.position = positions_i
-                traj.append(snapshot_j)
-
-            # change state of all jobs
-            for e_factor, sample_job in jobs_list:
-                sample_job = list(sample_job)[0]
-                sample_job.sp.n_steps = job.sp.PT_n_steps
-                sample_job.sp.kT = job.sp.PT_kT
-                sample_job.doc["done"] = False
-            # resume signac jobs
-            try:
-                MyProject().submit()
+                # attempting a swap
                 print("----------------------")
-                print("Successfully resumed {} project...".format(job.sp.mode))
+                print("Initiating a swap...")
                 print("----------------------")
-                logger.info("Successfully resumed {} project...".format(job.sp.mode))
-            except Exception as error:
-                logger.error(f"Error at line: {error.args[0]}")
-                raise RuntimeError("project resume failed")
-        else:
-            job.doc["done"] = True
+                project = signac.get_project()
+                sim_jobs = project.find_jobs({"doc.job_type": "sim"}).groupby("e_factor")
+                # find a random job and a neighbor to swap their configurations
+                i = random.randint(1, len(sim_jobs) - 1)
+                # find the neighbor with lower e_factor (equivalent to higher T)
+                j = i - 1
+                e_factor_i = sim_jobs[i][0]
+                job_i = list(sim_jobs[i][1])[0]
+
+                e_factor_j = sim_jobs[j][0]
+                job_j = list(sim_jobs[j][1])[0]
+                # TODO: get potential energy for both and calculate acceptance criteria.
+                print("----------------------")
+                print("Swapping e_factor {} with {}...".format(e_factor_i, e_factor_j))
+                print("----------------------")
+                # Accepting the swap
+                job.doc["swap_history"].append({"i": i, "j": j, "e_factor_i": e_factor_i, "e_factor_j": e_factor_j,
+                                                "job_i": job_i, "job_j": job_j, "done": False})
+                job.doc["current_attempt"] += 1
+
+                snapshot_i = gsd.hoomd.open(job_i.fn("snapshot.gsd"))[0]
+                positions_i = copy.deepcopy(snapshot_i.particles.position)
+
+                snapshot_j = job_j.fn("snapshot.gsd")[0]
+                positions_j = copy.deepcopy(snapshot_i.particles.position)
+
+                # swap positions and save snapshot
+                with gsd.hoomd.open(job_i.fn("snapshot.gsd"), "w") as traj:
+                    snapshot_i.particle.position = positions_j
+                    traj.append(snapshot_i)
+
+                with gsd.hoomd.open(job_j.fn("snapshot.gsd"), "w") as traj:
+                    snapshot_j.particle.position = positions_i
+                    traj.append(snapshot_j)
+
+                # submit simulations
+                submit_sims(job, MyProject())
+
+        job.doc["done"] = True
 
 
 if __name__ == "__main__":
-    MyProject().main()
+    PT_Project().main()

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -1,0 +1,160 @@
+"""Define the project's workflow logic and operation functions.
+Execute this script directly from the command line, to view your project's
+status, execute operations and submit them to a cluster. See also:
+    $ python src/project.py --help
+"""
+import sys
+import os
+
+# getting the name of the directory
+# where the this file is present.
+current = os.path.dirname(os.path.realpath(__file__))
+
+# Getting the parent directory name
+# where the current directory is present.
+parent = os.path.dirname(current)
+
+# adding the parent directory to
+# the sys.path.
+sys.path.append(parent)
+
+from flow import FlowProject, directives
+from flow.environment import DefaultSlurmEnvironment
+import signac
+import random
+import copy
+import gsd.hoomd
+
+
+class MyProject(FlowProject):
+    pass
+
+
+class Borah(DefaultSlurmEnvironment):
+    hostname_pattern = "borah"
+    template = "../templates/borah.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="short",
+            help="Specify the partition to submit to."
+        )
+
+
+class R2(DefaultSlurmEnvironment):
+    hostname_pattern = "r2"
+    template = "../templates/r2.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="shortq",
+            help="Specify the partition to submit to."
+        )
+
+
+class Fry(DefaultSlurmEnvironment):
+    hostname_pattern = "fry"
+    template = "../templates/fry.sh"
+
+    @classmethod
+    def add_args(cls, parser):
+        parser.add_argument(
+            "--partition",
+            default="batch",
+            help="Specify the partition to submit to."
+        )
+
+
+# Definition of project-related labels (classification)
+@MyProject.label
+def finished(job):
+    return job.doc.get("done")
+
+
+@MyProject.label
+def initialized(job):
+    return job.doc.get("current_attempt") > 0
+
+
+@directives(executable="python -u")
+@MyProject.operation
+@MyProject.post(finished)
+def sample(job):
+    with job:
+        print("-----------------------")
+        print("JOB ID NUMBER:")
+        print(job.id)
+        print("-----------------------")
+        # find signac project
+        project = signac.get_project(job.sp.workspace)
+        jobs_list = project.find_jobs().groupby("e_factor")
+
+        # First, making sure the previous swap (if exists) was finished successfully
+        if job.doc["current_attempt"] > 0:
+            # find the last swap
+            last_swap = job.doc["swap_history"][-1]
+
+            job_i = project.open_job(id=last_swap["job_i"])
+            job_j = project.open_job(id=last_swap["job_j"])
+
+            # TODO: probably need to check all the jobs, but for now we only check i & j status
+            try:
+                assert job_i.doc["done"] and job_j.doc["done"]
+                job.doc["swap_history"][-1]["done"] = True
+            except AssertionError:
+                # previous swap was unsuccessful, need to repeat.
+                job.doc["current_attempt"] -= 1
+
+        if job.doc["current_attempt"] <= job.sp.n_attempts:
+            print("----------------------")
+            print("Initiating a swap...")
+            print("----------------------")
+            # find a random job and a neighbor to swap their configurations
+            i = random.randint(1, len(jobs_list) - 1)
+            # find the neighbor with lower e_factor (equivalent to higher T)
+            j = i - 1
+            e_factor_i= jobs_list[i][0]
+            job_i = list(jobs_list[i][1])[0]
+
+            e_factor_j= jobs_list[j][0]
+            job_j = list(jobs_list[j][1])[0]
+            # TODO: get potential energy for both and calculate acceptance criteria.
+
+            print("----------------------")
+            print("Swapping e_factor {} with {}...".format(e_factor_i, e_factor_j))
+            print("----------------------")
+            # Accepting the swap
+            job.doc["swap_history"].append({"i": i, "j": j, "e_factor_i": e_factor_i, "e_factor_j": e_factor_j,
+                                            "job_i": job_i , "job_j": job_j, "done": False})
+            job.doc["current_attempt"] += 1
+
+            snapshot_i = gsd.hoomd.open(job_i.fn("snapshot.gsd"))[0]
+            positions_i = copy.deepcopy(snapshot_i.particles.position)
+
+            snapshot_j = job_j.fn("snapshot.gsd")[0]
+            positions_j = copy.deepcopy(snapshot_i.particles.position)
+
+            # swap positions and save snapshot
+            with gsd.hoomd.open(job_i.fn("snapshot.gsd"), "w") as traj:
+                snapshot_i.particle.position = positions_j
+                traj.append(snapshot_i)
+
+            with gsd.hoomd.open(job_j.fn("snapshot.gsd"), "w") as traj:
+                snapshot_j.particle.position = positions_i
+                traj.append(snapshot_j)
+
+            # change state of all jobs
+            for e_factor, sample_job in jobs_list:
+                sample_job = list(sample_job)[0]
+                sample_job.doc["done"] = False
+
+        else:
+            job.doc["done"] = True
+
+
+if __name__ == "__main__":
+    MyProject().main()

--- a/PT-flow/parallel_tempering.py
+++ b/PT-flow/parallel_tempering.py
@@ -189,12 +189,14 @@ def sample(job):
                 print("----------------------")
             except Exception as error:
                 logger.error(f"Error at line: {error.args[0]}")
-                raise RuntimeError("project init failed")
+                raise RuntimeError("project init failed. {}".format(error.args[0]))
 
             submit_sims(job, MyProject())
 
         while job.doc["current_attempt"] <= job.sp.n_attempts:
+            print('current swap: ', job.doc["current_attempt"])
             # First, making sure the simulations are finished
+            print("checking status of simulations...")
             if check_status(init_wait, extra_wait, max_tries):
                 if job.doc["current_attempt"] > 0:
                     # find the last swap


### PR DESCRIPTION
**Code is still in progress...**
This PR contains the main code for performing PT swaps and logging results.
Currently, the assumption is that we are running MCMC simulations. 
The main function in `PT-flow` tracks the number of swap attempts (`current_attempt`) and based on that, performs a couple of operations as below: 

- **First time run (`current_attempt=0`)**: Initiates the MCMC-flow signac project and submit it. 
(P.S. I am trying to find a way to check the status of jobs within the same script and wait until jobs are done. (maybe with a `while` loop.)
- (`current_attempt>0`): Finds two neighbors to swap (i & j). Loads their snapshot and swap positions. Set the state of all jobs to `False` and submits them again.
